### PR TITLE
Wire up tw-reset preflight

### DIFF
--- a/form-preflight/main.js
+++ b/form-preflight/main.js
@@ -1,3 +1,1 @@
-// @unocss-include
-import './tw-reset.css' // this can probably go away once tw-reset is a part of the plugin
 import 'uno.css'

--- a/form-preflight/package.json
+++ b/form-preflight/package.json
@@ -11,7 +11,6 @@
   },
   "devDependencies": {
     "@nmp-ds/engine": "workspace:*",
-    "lightningcss": "^1.18.0",
     "mini-svg-data-uri": "^1.4.4",
     "unocss": "^0.48.4",
     "vite": "^4.0.0"

--- a/form-preflight/vite.config.js
+++ b/form-preflight/vite.config.js
@@ -4,6 +4,6 @@ import { presetEngine } from '@nmp-ds/engine'
 
 export default defineConfig({
   plugins: [
-    UnoCSS({ presets: [presetEngine()] })
+    UnoCSS({ presets: [presetEngine({ mode: 'hyper' })] })
   ]
 })

--- a/plugin/dev.js
+++ b/plugin/dev.js
@@ -7,8 +7,8 @@ import presetEngine from './src/index.js'
 // console.log(generated.matched.size === staticProperties.length)
 
 const uno = createGenerator({
-  presets: [presetEngine()]
+  presets: [presetEngine({ mode: 'hyper' })]
 })
 
-const result = await uno.generate(['col-span-2', 'col-span-'], { preflights: false })
+const result = await uno.generate(['col-span-2', 'col-span-'])
 console.log(result.css)

--- a/plugin/src/_preflights/tw-reset.js
+++ b/plugin/src/_preflights/tw-reset.js
@@ -1,3 +1,6 @@
+export const twReset = {
+  layer: 'preflights',
+  getCSS: () => `
 /*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
 2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
@@ -16,7 +19,7 @@
 1. Use a consistent sensible line-height in all browsers.
 2. Prevent adjustments of font size after orientation changes in iOS.
 3. Use a more readable tab size.
-4. Use the user's configured `sans` font-family by default.
+4. Use the user's configured 'sans' font-family by default.
 */
 
 html {
@@ -29,7 +32,7 @@ html {
 
 /*
 1. Remove the margin in all browsers.
-2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+2. Inherit line-height from 'html' so users can set them as a class directly on the 'html' element.
 */
 
 body {
@@ -90,8 +93,8 @@ strong {
 }
 
 /*
-1. Use the user's configured `mono` font family by default.
-2. Correct the odd `em` font sizing in all browsers.
+1. Use the user's configured 'mono' font family by default.
+2. Correct the odd 'em' font sizing in all browsers.
 */
 
 code,
@@ -111,7 +114,7 @@ small {
 }
 
 /*
-Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
 */
 
 sub,
@@ -194,7 +197,7 @@ Use the modern Firefox focus style for all focusable elements.
 }
 
 /*
-Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+Remove the additional ':invalid' styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
 */
 
 :-moz-ui-invalid {
@@ -238,7 +241,7 @@ Remove the inner padding in Chrome and Safari on macOS.
 
 /*
 1. Correct the inability to style clickable types in iOS and Safari.
-2. Change font properties to `inherit` in Safari.
+2. Change font properties to 'inherit' in Safari.
 */
 
 ::-webkit-file-upload-button {
@@ -327,8 +330,8 @@ Make sure disabled buttons don't get the pointer cursor.
 }
 
 /*
-1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
-2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+1. Make replaced elements 'display: block' by default. (https://github.com/mozdevs/cssremedy/issues/14)
+2. Add 'vertical-align: middle' to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
    This can trigger a poorly considered lint error in some tools but is included by design.
 */
 
@@ -352,4 +355,6 @@ img,
 video {
   max-width: 100%;
   height: auto;
+}
+  `
 }

--- a/plugin/src/index.js
+++ b/plugin/src/index.js
@@ -1,22 +1,25 @@
 // import { preflights } from './preflights.js'
 import { formPreflight } from '@nmp-ds/form-preflight'
+import { twReset } from './_preflights/tw-reset.js'
 import { rules } from '#rules'
 import { variants } from '#variants'
 import { theme } from './theme.js'
+
+const includePreflight = ['base', 'hyper']
 
 // export { theme, colors } from './theme.js'
 
 // TODO: improve generic type passed here
 /** @type {import('@unocss/core').Preset<object>} */
 export function presetEngine (options = {}) {
+  const mode = options.mode ?? 'app'
+  const hasPreflight = includePreflight.includes(mode)
   return {
     name: '@nmp-ds/engine',
     theme,
     rules,
     variants,
-    preflights: [
-      formPreflight
-    ]
+    preflights: hasPreflight ? [twReset, formPreflight] : []
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,11 @@ importers:
   form-preflight:
     specifiers:
       '@nmp-ds/engine': workspace:*
-      lightningcss: ^1.18.0
       mini-svg-data-uri: ^1.4.4
       unocss: ^0.48.4
       vite: ^4.0.0
     devDependencies:
       '@nmp-ds/engine': link:../plugin
-      lightningcss: 1.18.0
       mini-svg-data-uri: 1.4.4
       unocss: 0.48.4_vite@4.0.4
       vite: 4.0.4
@@ -650,12 +648,6 @@ packages:
     resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
     dev: true
 
-  /detect-libc/1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-    dev: true
-
   /diff/5.1.0:
     resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
@@ -851,94 +843,6 @@ packages:
 
   /kolorist/1.6.0:
     resolution: {integrity: sha512-dLkz37Ab97HWMx9KTes3Tbi3D1ln9fCAy2zr2YVExJasDRPGRaKcoE4fycWNtnCAJfjFqe0cnY+f8KT2JePEXQ==}
-    dev: true
-
-  /lightningcss-darwin-arm64/1.18.0:
-    resolution: {integrity: sha512-OqjydwtiNPgdH1ByIjA1YzqvDG/OMR6L3LPN6wRl1729LB0y4Mik7L06kmZaTb+pvUHr+NmDd2KCwnlrQ4zO3w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-darwin-x64/1.18.0:
-    resolution: {integrity: sha512-mNiuPHj89/JHZmJMp+5H8EZSt6EL5DZRWJ31O6k3DrLLnRIQjXuXdDdN8kP7LoIkeWI5xvyD60CsReJm+YWYAw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-arm-gnueabihf/1.18.0:
-    resolution: {integrity: sha512-S+25JjI6601HiAVoTDXW6SqH+E94a+FHA7WQqseyNHunOgVWKcAkNEc2LJvVxgwTq6z41sDIb9/M3Z9wa9lk4A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-arm64-gnu/1.18.0:
-    resolution: {integrity: sha512-JSqh4+21dCgBecIQUet35dtE4PhhSEMyqe3y0ZNQrAJQ5kyUPSQHiw81WXnPJcOSTTpG0TyMLiC8K//+BsFGQA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-arm64-musl/1.18.0:
-    resolution: {integrity: sha512-2FWHa8iUhShnZnqhn2wfIcK5adJat9hAAaX7etNsoXJymlliDIOFuBQEsba2KBAZSM4QqfQtvRdR7m8i0I7ybQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-x64-gnu/1.18.0:
-    resolution: {integrity: sha512-plCPGQJtDZHcLVKVRLnQVF2XRsIC32WvuJhQ7fJ7F6BV98b/VZX0OlX05qUaOESD9dCDHjYSfxsgcvOKgCWh7A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-linux-x64-musl/1.18.0:
-    resolution: {integrity: sha512-na+BGtVU6fpZvOHKhnlA0XHeibkT3/46nj6vLluG3kzdJYoBKU6dIl7DSOk++8jv4ybZyFJ0aOFMMSc8g2h58A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss-win32-x64-msvc/1.18.0:
-    resolution: {integrity: sha512-5qeAH4RMNy2yMNEl7e5TI6upt/7xD2ZpHWH4RkT8iJ7/6POS5mjHbXWUO9Q1hhDhqkdzGa76uAdMzEouIeCyNw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /lightningcss/1.18.0:
-    resolution: {integrity: sha512-uk10tNxi5fhZqU93vtYiQgx/8a9f0Kvtj5AXIm+VlOXY+t/DWDmCZWJEkZJmmALgvbS6aAW8or+Kq85eJ6TDTw==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      detect-libc: 1.0.3
-    optionalDependencies:
-      lightningcss-darwin-arm64: 1.18.0
-      lightningcss-darwin-x64: 1.18.0
-      lightningcss-linux-arm-gnueabihf: 1.18.0
-      lightningcss-linux-arm64-gnu: 1.18.0
-      lightningcss-linux-arm64-musl: 1.18.0
-      lightningcss-linux-x64-gnu: 1.18.0
-      lightningcss-linux-x64-musl: 1.18.0
-      lightningcss-win32-x64-msvc: 1.18.0
     dev: true
 
   /local-pkg/0.4.2:


### PR DESCRIPTION
- Starts adding support for 'modes'
- The `hyper` mode is just a temporary name, but is the mode that assume zero NMP infrastructure (e.g. base.css, theme.css)