### PR TITLE
Add rules for inset and top, left, right bottom classes

### DIFF
--- a/plugin/dev.js
+++ b/plugin/dev.js
@@ -2,5 +2,5 @@ import { createGenerator } from '@unocss/core'
 import presetEngine from './src/index.js'
 
 const uno = createGenerator({ presets: [presetEngine()] })
-const result = await uno.generate(['row-span-2', 'row-span-10000', 'gap-32', '!sm:pa-16', '-m-2', 'pa-18', '!ma-16', 'opacity-50', 'align-top', 'line-clamp-2'])
+const result = await uno.generate(['top-1', 'left-1', 'right-1', 'bottom-1', '-inset-2', 'inset-1/2', 'inset-full', 'inset-auto', 'inset-y-1', 'row-span-2', 'row-span-10000', 'gap-32', '!sm:pa-16', '-m-2', 'pa-18', '!ma-16', 'opacity-50', 'align-top', 'line-clamp-2'])
 console.log(result.css)

--- a/plugin/src/_rules/index.js
+++ b/plugin/src/_rules/index.js
@@ -6,6 +6,7 @@ import { display } from './display.js'
 import { lineClamp } from './line-clamp.js'
 import { padding, margin } from './spacing.js'
 import { gap } from './gap.js'
+import { insets } from "./position.js"
 
 export const rules = [
   verticalAligns, textAligns,
@@ -16,6 +17,7 @@ export const rules = [
   lineClamp,
   gap,
   padding, margin,
+  insets
 ].flat(1)
 
 export * from './align.js'
@@ -25,3 +27,4 @@ export * from './color.js'
 export * from './display.js'
 export * from './spacing.js'
 export * from './gap.js'
+export * from "./position.js" 

--- a/plugin/src/_rules/position.js
+++ b/plugin/src/_rules/position.js
@@ -1,0 +1,24 @@
+import { handler as h, insetMap } from '#utils';
+
+function handleInsetValue(v, { theme }) {
+    return theme.spacing?.[v] ?? h.fraction.auto(v); // TODO: warn if no value
+}
+function handleInsetValues([, d, v], ctx) {
+    const r = handleInsetValue(v, ctx);
+    if (r != null && d in insetMap)
+        return insetMap[d].map(i => [i.slice(1), r]);
+}
+export const insets = [
+    [/^inset-(.+)$/, ([, v], ctx) => ({ inset: handleInsetValue(v, ctx) }),
+        {
+            autocomplete: [
+                '(inset-<directions>-$spacing',
+                'inset-(block|inline)-$spacing',
+                'inset-(bs|be|is|ie)-$spacing',
+                '(top|left|right|bottom)-$spacing',
+            ],
+        },
+    ],
+    [/^inset-([xy])-(.+)$/, handleInsetValues],
+    [/^(top|left|right|bottom)-(.+)$/, ([, d, v], ctx) => ({ [d]: handleInsetValue(v, ctx) })],
+];

--- a/plugin/src/_rules/position.js
+++ b/plugin/src/_rules/position.js
@@ -12,9 +12,8 @@ export const insets = [
     [/^inset-(.+)$/, ([, v], ctx) => ({ inset: handleInsetValue(v, ctx) }),
         {
             autocomplete: [
-                '(inset-<directions>-$spacing',
-                'inset-(block|inline)-$spacing',
-                'inset-(bs|be|is|ie)-$spacing',
+                '(inset-$spacing',
+                '(inset-<direction>-$spacing',
                 '(top|left|right|bottom)-$spacing',
             ],
         },

--- a/plugin/src/theme.js
+++ b/plugin/src/theme.js
@@ -30,7 +30,8 @@ const spacing = {
   80: '8rem',
   96: '9.6rem',
   112: '11.2rem',
-  128: '12.8rem'
+  128: '12.8rem',
+  144: '14.4rem'
 }
 
 export const theme = {


### PR DESCRIPTION
This adds rules for various inset classes and top, left, right, bottom.

rules support the following, value suffix can of course differ, bounding will be added later.

```
inset-auto
inset-full
inset-1/2
inset-y-1
inset-x-1
top-1
left-1
right-1
bottom-1
```

All credit to @BalbinaK  for setting this up 🙌 