### PR TITLE
Support global keywords in position rules

### DIFF
--- a/plugin/src/_rules/position.js
+++ b/plugin/src/_rules/position.js
@@ -1,4 +1,4 @@
-import { handler as h, insetMap } from '#utils';
+import { handler as h, insetMap, makeGlobalStaticRules } from '#utils';
 import { bounded } from "#bounding";
 
 
@@ -25,14 +25,14 @@ export const justifies = [
     ['justify-between', { 'justify-content': 'space-between' }],
     ['justify-around', { 'justify-content': 'space-around' }],
     ['justify-evenly', { 'justify-content': 'space-evenly' }],
-    // ...makeGlobalStaticRules('justify', 'justify-content'),
+    ...makeGlobalStaticRules('justify', 'justify-content'),
 
     // items
     ['justify-items-start', { 'justify-items': 'start' }],
     ['justify-items-end', { 'justify-items': 'end' }],
     ['justify-items-center', { 'justify-items': 'center' }],
     ['justify-items-stretch', { 'justify-items': 'stretch' }],
-    // ...makeGlobalStaticRules('justify-items'),
+    ...makeGlobalStaticRules('justify-items'),
 
     // selfs
     ['justify-self-auto', { 'justify-self': 'auto' }],
@@ -40,7 +40,7 @@ export const justifies = [
     ['justify-self-end', { 'justify-self': 'end' }],
     ['justify-self-center', { 'justify-self': 'center' }],
     ['justify-self-stretch', { 'justify-self': 'stretch' }],
-    // ...makeGlobalStaticRules('justify-self'),
+    ...makeGlobalStaticRules('justify-self'),
 ]
 
 export const alignments = [
@@ -51,7 +51,7 @@ export const alignments = [
     ['content-between', { 'align-content': 'space-between' }],
     ['content-around', { 'align-content': 'space-around' }],
     ['content-evenly', { 'align-content': 'space-evenly' }],
-    // ...makeGlobalStaticRules('content', 'align-content'),
+    ...makeGlobalStaticRules('content', 'align-content'),
 
     // items
     ['items-start', { 'align-items': 'flex-start' }],
@@ -59,7 +59,7 @@ export const alignments = [
     ['items-center', { 'align-items': 'center' }],
     ['items-baseline', { 'align-items': 'baseline' }],
     ['items-stretch', { 'align-items': 'stretch' }],
-    // ...makeGlobalStaticRules('items', 'align-items'),
+    ...makeGlobalStaticRules('items', 'align-items'),
 
     // selfs
     ['self-auto', { 'align-self': 'auto' }],
@@ -68,7 +68,7 @@ export const alignments = [
     ['self-center', { 'align-self': 'center' }],
     ['self-stretch', { 'align-self': 'stretch' }],
     ['self-baseline', { 'align-self': 'baseline' }],
-    // ...makeGlobalStaticRules('self', 'align-self'),
+    ...makeGlobalStaticRules('self', 'align-self'),
 ]
 
 export const placements = [
@@ -80,14 +80,14 @@ export const placements = [
     ['place-content-around', { 'place-content': 'space-around' }],
     ['place-content-evenly', { 'place-content': 'space-evenly' }],
     ['place-content-stretch', { 'place-content': 'stretch' }],
-    // ...makeGlobalStaticRules('place-content'),
+    ...makeGlobalStaticRules('place-content'),
 
     // items
     ['place-items-start', { 'place-items': 'start' }],
     ['place-items-end', { 'place-items': 'end' }],
     ['place-items-center', { 'place-items': 'center' }],
     ['place-items-stretch', { 'place-items': 'stretch' }],
-    // ...makeGlobalStaticRules('place-items'),
+    ...makeGlobalStaticRules('place-items'),
 
     // selfs
     ['place-self-auto', { 'place-self': 'auto' }],
@@ -95,7 +95,7 @@ export const placements = [
     ['place-self-end', { 'place-self': 'end' }],
     ['place-self-center', { 'place-self': 'center' }],
     ['place-self-stretch', { 'place-self': 'stretch' }],
-    // ...makeGlobalStaticRules('place-self'),
+    ...makeGlobalStaticRules('place-self'),
 ]
 
 function handleInsetValue(v, { theme }) {

--- a/plugin/test/position.js
+++ b/plugin/test/position.js
@@ -1,5 +1,6 @@
 import { setup } from './_helpers.js'
 import { theme } from '#theme'
+import { globalKeywords } from "#utils"
 import { describe, expect, test } from 'vitest'
 
 setup()
@@ -203,6 +204,64 @@ describe('placements', () => {
       .place-self-end{place-self:end;}
       .place-self-center{place-self:center;}
       .place-self-stretch{place-self:stretch;}"
+    `)
+  })
+})
+
+describe("global keywords", () => {
+
+  test('justify, alignments and placements should work with global keywords', async ({ uno }) => {
+    const classes = ["justify", "justify-items", "justify-self", "content", "items", "self", "place-content", "place-items", "place-self"]
+      .map(prefix => globalKeywords.map(keyword => `${prefix}-${keyword}`)).flat()
+
+    const { css } = await uno.generate(classes)
+    expect(css).toMatchInlineSnapshot(`
+      "/* layer: default */
+      .justify-inherit{justify-content:inherit;}
+      .justify-initial{justify-content:initial;}
+      .justify-revert{justify-content:revert;}
+      .justify-revert-layer{justify-content:revert-layer;}
+      .justify-unset{justify-content:unset;}
+      .justify-items-inherit{justify-items:inherit;}
+      .justify-items-initial{justify-items:initial;}
+      .justify-items-revert{justify-items:revert;}
+      .justify-items-revert-layer{justify-items:revert-layer;}
+      .justify-items-unset{justify-items:unset;}
+      .justify-self-inherit{justify-self:inherit;}
+      .justify-self-initial{justify-self:initial;}
+      .justify-self-revert{justify-self:revert;}
+      .justify-self-revert-layer{justify-self:revert-layer;}
+      .justify-self-unset{justify-self:unset;}
+      .content-inherit{align-content:inherit;}
+      .content-initial{align-content:initial;}
+      .content-revert{align-content:revert;}
+      .content-revert-layer{align-content:revert-layer;}
+      .content-unset{align-content:unset;}
+      .items-inherit{align-items:inherit;}
+      .items-initial{align-items:initial;}
+      .items-revert{align-items:revert;}
+      .items-revert-layer{align-items:revert-layer;}
+      .items-unset{align-items:unset;}
+      .self-inherit{align-self:inherit;}
+      .self-initial{align-self:initial;}
+      .self-revert{align-self:revert;}
+      .self-revert-layer{align-self:revert-layer;}
+      .self-unset{align-self:unset;}
+      .place-content-inherit{place-content:inherit;}
+      .place-content-initial{place-content:initial;}
+      .place-content-revert{place-content:revert;}
+      .place-content-revert-layer{place-content:revert-layer;}
+      .place-content-unset{place-content:unset;}
+      .place-items-inherit{place-items:inherit;}
+      .place-items-initial{place-items:initial;}
+      .place-items-revert{place-items:revert;}
+      .place-items-revert-layer{place-items:revert-layer;}
+      .place-items-unset{place-items:unset;}
+      .place-self-inherit{place-self:inherit;}
+      .place-self-initial{place-self:initial;}
+      .place-self-revert{place-self:revert;}
+      .place-self-revert-layer{place-self:revert-layer;}
+      .place-self-unset{place-self:unset;}"
     `)
   })
 })


### PR DESCRIPTION
Add support for global keywords to rules in position.js, as suggested in a comment from https://github.com/warp-ds/engine/pull/4#discussion_r1086772020