### PR TITLE
fix(shadow): update naming of box-shadows

### DIFF
--- a/src/_rules/shadow.js
+++ b/src/_rules/shadow.js
@@ -3,15 +3,14 @@
 const defaultColor = 'rgba(0, 0, 0, .2)';
 
 const boxShadowDefaults = {
-  small: `0 1px 6px ${defaultColor}, 0 1px 1px ${defaultColor}`,
-  medium: `0 3px 8px ${defaultColor}, 0 3px 6px ${defaultColor}`,
-  large: `0 6px 8px ${defaultColor}, 0 10px 20px ${defaultColor}`,
-  xlarge: `0 9px 12px ${defaultColor}, 0 14px 28px ${defaultColor}`,
+  s: `0 1px 6px ${defaultColor}, 0 1px 1px ${defaultColor}`,
+  m: `0 3px 8px ${defaultColor}, 0 3px 6px ${defaultColor}`,
+  l: `0 6px 8px ${defaultColor}, 0 10px 20px ${defaultColor}`,
+  xl: `0 9px 12px ${defaultColor}, 0 14px 28px ${defaultColor}`,
 };
 
-// TODO: rename to -s, -m, -l, -xs
 export const shadows = [
-  [/^shadow-(small|medium|large|xlarge)$/, ([, size]) => ({ 'box-shadow': `var(--w-shadow-${size}, ${boxShadowDefaults[size]})` })],
+  [/^shadow-(s|m|l|xl)$/, ([, size]) => ({ 'box-shadow': `var(--w-shadow-${size}, ${boxShadowDefaults[size]})` })],
 ];
 
 const dropShadowDefaultColor = '64, 64, 64';

--- a/test/__snapshots__/shadow.js.snap
+++ b/test/__snapshots__/shadow.js.snap
@@ -10,8 +10,8 @@ exports[`drop shadows 1`] = `
 
 exports[`shadows work 1`] = `
 "/* layer: default */
-.shadow-large{box-shadow:var(--w-shadow-large, 0 6px 8px rgba(0, 0, 0, .2), 0 10px 20px rgba(0, 0, 0, .2));}
-.shadow-medium{box-shadow:var(--w-shadow-medium, 0 3px 8px rgba(0, 0, 0, .2), 0 3px 6px rgba(0, 0, 0, .2));}
-.shadow-small{box-shadow:var(--w-shadow-small, 0 1px 6px rgba(0, 0, 0, .2), 0 1px 1px rgba(0, 0, 0, .2));}
-.shadow-xlarge{box-shadow:var(--w-shadow-xlarge, 0 9px 12px rgba(0, 0, 0, .2), 0 14px 28px rgba(0, 0, 0, .2));}"
+.shadow-l{box-shadow:var(--w-shadow-l, 0 6px 8px rgba(0, 0, 0, .2), 0 10px 20px rgba(0, 0, 0, .2));}
+.shadow-m{box-shadow:var(--w-shadow-m, 0 3px 8px rgba(0, 0, 0, .2), 0 3px 6px rgba(0, 0, 0, .2));}
+.shadow-s{box-shadow:var(--w-shadow-s, 0 1px 6px rgba(0, 0, 0, .2), 0 1px 1px rgba(0, 0, 0, .2));}
+.shadow-xl{box-shadow:var(--w-shadow-xl, 0 9px 12px rgba(0, 0, 0, .2), 0 14px 28px rgba(0, 0, 0, .2));}"
 `;

--- a/test/shadow.js
+++ b/test/shadow.js
@@ -4,7 +4,7 @@ import { setup } from './_helpers.js';
 setup();
 
 test('shadows work', async ({ uno }) => {
-  const classes = ['shadow-small', 'shadow-medium', 'shadow-large', 'shadow-xlarge'];
+  const classes = ['shadow-s', 'shadow-m', 'shadow-l', 'shadow-xl'];
   const { css } = await uno.generate(classes);
   expect(css).toMatchSnapshot();
 });


### PR DESCRIPTION
prefix change for shadows: 

Previous:
`shadow-small`, `shadow-medium`, `shadow-large`, `shadow-xlarge`

New:
`shadow-s`, `shadow-m`, `shadow-l`, `shadow-xl`