### PR TITLE
feat: enable arbitrary variants

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -27,7 +27,7 @@ const {
 const uno = await createGenerator({
   presets: [presetWarp({ ...options, development: true })],
 });
-const devClasses = ['m-16!', 'opacity-50'];
+const devClasses = ['m-16!', 'opacity-50', '[&>[role="tablist"]]:flex'];
 const classes = cliClasses ?? devClasses;
 const result = await uno.generate(classes);
 console.log(result.css);

--- a/src/_variants/index.js
+++ b/src/_variants/index.js
@@ -9,6 +9,7 @@ import {
   variantCombinators,
   variantDataAttribute,
   variantAria,
+  variantVariables,
 } from '@unocss/preset-mini/variants';
 
 import { variantLastChild } from './lastChild.js';
@@ -27,6 +28,7 @@ export const variants = [
   ...variantCombinators,
   variantDataAttribute,
   variantAria,
+  variantVariables,
 ];
 
 export {
@@ -42,4 +44,5 @@ export {
   variantCombinators,
   variantDataAttribute,
   variantAria,
+  variantVariables,
 };


### PR DESCRIPTION
## What's changed
This change enables usage of [arbitrary variants](https://tailwindcss.com/docs/hover-focus-and-other-states#using-arbitrary-variants) with UnoCSS and Warp preset. Unfortunately, this feature is not that well documented in UnoCSS but it works just like in Tailwind, so I'll use their docs to explain its benefits:

_"Just like [arbitrary values](https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values) let you use custom values with the utility classes, **arbitrary variants** let you write custom selector variants directly in the HTML. Arbitrary variants are just format strings that represent the selector, wrapped in square brackets."_

## Examples
We could use arbitrary variants to style elements based on their attributes, or style their children in case they cannot be styled directly. Here are some examples of styles generated by UnoCSS with the updated `warpPreset`:
<table>
  <thead>
    <tr>
      <th>arbitrary variant</th>
      <th>CSS</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><code>[&amp;[open]]:p-2</code></td>
      <td><code>.[&amp;[open]]:p-2[open] { padding: 0.2rem; }</code></td>
    </tr>
    <tr>
      <td><code>[@supports(display:grid)]:grid</code></td>
      <td>
        <pre><code>@supports(display:grid) {
  .[@supports(display:grid)]:grid {
    display: grid;
  }
}</code></pre>
      </td>
    </tr>
    <tr>
      <td><code>[&.open]:block</code></td>
      <td><code>.[&.open]:block.open { display: block; }</code></td>
    </tr>
    <tr>
      <td><code>[&>[role="tablist"]]:flex</code></td>
      <td><pre><code>.[&>[role="tablist"]]:flex>[role="tablist"]{ 
  display: flex; 
}</code></pre></td>
    </tr>
    <tr>
      <td><code>[&_p]:m-8</code></td>
      <td><code>.[&_p]:m-8 p{ margin: 0.8rem; }</code></td>
    </tr>
  </tbody>
</table>

## Background
This PR is a result of an attempt to style the React Tabs component's `div` element with `role="tablist"` that cannot be styled using props. That div is set to display all containing Tab buttons in `inline-grid`, which we needed to override with `flex` in the case of too many buttons being shown:
### with `display: inline-grid`
<img width="554" height="112" alt="Screenshot 2025-11-27 at 16 18 48" src="https://github.com/user-attachments/assets/8fbec98b-205d-4292-ac56-036a9550ea61" />

### with `display: flex`
<img width="569" height="114" alt="Screenshot 2025-11-27 at 16 20 59" src="https://github.com/user-attachments/assets/0e5dc935-71ea-4050-acb0-70142d28d1d8" />

## Testing
Add arbitrary variants to the `devClasses` array in `dev.js` file and run `pnpm dev`. The output CSS will be logged in the terminal.