### PR TITLE
feat: add dark/light mode variants support

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -27,7 +27,7 @@ const {
 const uno = await createGenerator({
   presets: [presetWarp({ ...options, development: true })],
 });
-const devClasses = ['m-16!', 'opacity-50', '[&>[role="tablist"]]:flex'];
+const devClasses = ['m-16!', 'opacity-50', '[&>[role="tablist"]]:flex', 'dark:s-bg-info-subtle', 'light:s-bg-subtle'];
 const classes = cliClasses ?? devClasses;
 const result = await uno.generate(classes);
 console.log(result.css);

--- a/src/_variants/index.js
+++ b/src/_variants/index.js
@@ -10,6 +10,7 @@ import {
   variantDataAttribute,
   variantAria,
   variantVariables,
+  variantColorsMediaOrClass,
 } from '@unocss/preset-mini/variants';
 
 import { variantLastChild } from './lastChild.js';
@@ -29,6 +30,7 @@ export const variants = [
   variantDataAttribute,
   variantAria,
   variantVariables,
+  ...variantColorsMediaOrClass({ dark: { dark: ['[data-w-theme=dark]'], light: ['[data-w-theme=light]'] } }),
 ];
 
 export {
@@ -45,4 +47,5 @@ export {
   variantDataAttribute,
   variantAria,
   variantVariables,
+  variantColorsMediaOrClass,
 };

--- a/test/__snapshots__/variants.js.snap
+++ b/test/__snapshots__/variants.js.snap
@@ -23,6 +23,12 @@ exports[`variants > custom 1`] = `
 .last-child\\:mb-0>:last-child{margin-bottom:0rem;}"
 `;
 
+exports[`variants > dark 1`] = `
+"/* layer: default */
+[data-w-theme=dark] .dark\\:s-bg-subtle{background-color:var(--w-s-color-background-subtle);}
+[data-w-theme=light] .light\\:s-text-inverted-static{color:var(--w-s-color-text-inverted-static);}"
+`;
+
 exports[`variants > data variant 1`] = `
 "/* layer: default */
 .data-\\[is-active\\]\\:s-bg-primary[data-is-active]{background-color:var(--w-s-color-background-primary);}"

--- a/test/variants.js
+++ b/test/variants.js
@@ -51,5 +51,12 @@ describe('variants', () => {
     const { css } = await uno.generate(classes);
     expect(css).toMatchSnapshot();
   });
+
+  test('dark', async ({ uno }) => {
+    const classes = ['dark:s-bg-subtle', 'light:s-text-inverted-static'];
+    const { css } = await uno.generate(classes);
+    expect(css).toMatchSnapshot();
+  });
+
   // space/divide variant is already tested by the space/divide classes
 });


### PR DESCRIPTION
## Summary

Add support for dark and light mode variants, enabling theme-aware styling through CSS class prefixes.

## Changes

- Integrate `variantColorsMediaOrClass` from UnoCSS to enable `dark:` and `light:` variant prefixes
- Configure variants to use `[data-w-theme=dark]` and `[data-w-theme=light]` selectors for theme targeting - based on a [proposal](https://sch-chat.slack.com/archives/C0AUGPLP59Q/p1781081946354549) to set those attributes on the `html` element when dark mode is active.
- Add test coverage for dark/light mode variants with actual CSS output validation